### PR TITLE
Add slack button and app functionality.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,14 @@
 
 const co = require('bluebird').coroutine
 
-const Redis = require('db/redis')
-const Server = require('server')
+const Redis = require('src/db/redis')
+const Spotify = require('src/spotify/app')
+const Server = require('src/server')
 
 co(function* () {
 
   yield Redis.init()
+  yield Spotify.init()
   Server.init()
 })()
 

--- a/package.json
+++ b/package.json
@@ -4,26 +4,30 @@
   "description": "A Slack-driven interface for Spotify.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "ava"
   },
   "author": "Shaun",
   "license": "ISC",
   "dependencies": {
-    "bluebird": "latest",
-    "body-parser": "^1.15.2",
-    "bunyan": "^1.8.5",
-    "config": "^1.24.0",
-    "express": "^4.14.0",
-    "js-yaml": "^3.7.0",
-    "lodash": "^4.17.4",
-    "morgan": "latest",
-    "nedb": "^1.8.0",
-    "request": "^2.79.0",
-    "request-promise": "^4.1.1",
-    "spotify-web-api-node": "^2.3.6",
-    "debug": "latest"
+    "bluebird": "3.4.7",
+    "body-parser": "1.15.2",
+    "bunyan": "1.8.5",
+    "config": "1.24.0",
+    "consolidate": "0.14.5",
+    "debug": "2.6.0",
+    "express": "4.14.0",
+    "js-yaml": "3.7.0",
+    "lodash": "4.17.4",
+    "morgan": "1.7.0",
+    "nedb": "1.8.0",
+    "redis": "2.6.5",
+    "request": "2.79.0",
+    "request-promise": "4.1.1",
+    "spotify-web-api-node": "2.3.6",
+    "swig": "1.4.2",
+    "x-www-form-urlencode": "0.1.1"
   },
   "devDependencies": {
-    "redis": "latest"
+    "ava": "^0.17.0"
   }
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,42 @@
+'use strict'
+
+module.exports = {
+  MESSAGING: {
+    UH_OH: `Uh-oh! Looks like we broke something 😅`, // :sweat_smile: emoji
+    WAIT_FOR_IT: `Wait for it...`,
+
+    SPOTIFY: {
+      getSONG_SUCCESSFULLY_ADDED: (trackName) => {
+        return `*${trackName}* has been added to the playlist! 🙌` // :hooray: emoji
+      }
+    }
+  },
+
+  SLACK: {
+    INTERACTIVE: {
+      SONG_SEARCH: {
+        CALLBACK_ID: 'song_search',
+        ACTION: {
+          ADD_SONG: {
+            NAME: 'add_song',
+            TEXT: 'Add to Playlist'
+          }
+        }
+      }
+    }
+  },
+
+  RESULT: {
+    STATUS: {
+      SUCCESS: 'success',
+      FAILURE: 'failure'
+    }
+  },
+
+  STORAGE_KEY: {
+    SPOTIFY: {
+      ACCESS_TOKEN: 'spotify:token:access',
+      REFRESH_TOKEN: 'spotify:token:refresh'
+    }
+  }
+}

--- a/src/db/redis.js
+++ b/src/db/redis.js
@@ -7,7 +7,7 @@ const redis = require('redis')
 Promise.promisifyAll(redis.RedisClient.prototype);
 Promise.promisifyAll(redis.Multi.prototype)
 
-const Logger = require('util/logger')
+const Logger = require('src/util/logger')
 
 const client = redis.createClient()
 

--- a/src/server/admin/router.js
+++ b/src/server/admin/router.js
@@ -1,8 +1,9 @@
 'use strict'
 
 const express = require('express')
-const Serializer = require('server/admin/serializer')
-const Spotify = require('spotify/app')
+
+const Serializer = require('src/server/admin/serializer')
+const Spotify = require('src/spotify/app')
 
 const router = express.Router({ mergeParams: true })
 

--- a/src/server/authorization/router.js
+++ b/src/server/authorization/router.js
@@ -3,8 +3,8 @@
 const express = require('express')
 
 const router = express.Router({ mergeParams: true })
-const SpotifyRouter = require('server/authorization/spotify')
-const SlackRouter = require('server/authorization/slack')
+const SpotifyRouter = require('src/server/authorization/spotify')
+const SlackRouter = require('src/server/authorization/slack')
 
 router.use('/spotify', SpotifyRouter)
 router.use('/slack', SlackRouter)

--- a/src/server/authorization/slack/index.js
+++ b/src/server/authorization/slack/index.js
@@ -5,7 +5,8 @@ const _ = require('lodash')
 const co = require('bluebird').coroutine
 const request = require('request-promise')
 const config = require('config')
-const Redis = require('db/redis')
+
+const Redis = require('src/db/redis')
 
 const router = express.Router({ mergeParams: true })
 
@@ -14,8 +15,11 @@ router.get('/callback', (req, res) => {
   co(function* () {
 
     const code = req.query.code
-    // TODO: Verify if state received is the state passed via button.
     const state = req.query.state
+
+    if (state !== config.get('slack.oAuthState')) {
+      throw new Error(`Received state: ${state} does not match configured state.`)
+    }
 
     const options = {
       uri: 'https://slack.com/api/oauth.access',

--- a/src/server/authorization/spotify/index.js
+++ b/src/server/authorization/spotify/index.js
@@ -1,18 +1,34 @@
 'use strict'
 
+const debug = require('debug')('authorization')
 const express = require('express')
 const co = require('bluebird').coroutine
-const Spotify = require('spotify/app')
+
+const Constants = require('src/constants')
+const Spotify = require('src/spotify/app')
+const Redis = require('src/db/redis')
 
 const router = express.Router({ mergeParams: true })
 
 router.get('/', (req, res) => {
+  return co(function* () {
 
-  if (Spotify.client.getAccessToken()) {
-    return res.send(`Looks like you're good to go!`);
-  }
+    let accessToken = Spotify.client.getAccessToken()
 
-  return res.redirect('/api/auth/spotify/authorize');
+    if (accessToken) {
+      debug(`Found Spotify access token in memory.`)
+    } else {
+      accessToken = yield Redis.client.getAsync(Constants.STORAGE_KEY.SPOTIFY.ACCESS_TOKEN)
+      Spotify.client.setAccessToken(accessToken)
+    }
+
+    if (!accessToken) {
+      debug(`Spotify access token not found in storage or memory. Beginning oAuth.`)
+      return res.redirect('/api/auth/spotify/authorize')
+    }
+
+    return res.send(`Looks like you're good to go!`)
+  })()
 })
 
 router.get('/authorize', (req, res) => {
@@ -25,13 +41,17 @@ router.get('/authorize', (req, res) => {
 })
 
 router.get('/callback', (req, res) => {
-
-  co(function* () {
+  return co(function* () {
 
     const data = yield Spotify.client.authorizationCodeGrant(req.query.code)
+    debug(`Spotify access and refresh tokens received.`)
 
     Spotify.client.setAccessToken(data.body['access_token'])
     Spotify.client.setRefreshToken(data.body['refresh_token'])
+
+    yield Redis.client.setAsync(Constants.STORAGE_KEY.SPOTIFY.ACCESS_TOKEN, data.body['access_token'])
+    yield Redis.client.setAsync(Constants.STORAGE_KEY.SPOTIFY.REFRESH_TOKEN, data.body['refresh_token'])
+    debug(`Spotify access and refresh tokens stored.`)
 
     return res.redirect('/')
   })()

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -4,11 +4,12 @@ const express = require('express')
 const bodyParser = require('body-parser')
 const morgan = require('morgan')
 const config = require('config')
+const cons = require('consolidate')
 
-const AuthorizationRouter = require('server/authorization/router')
-const AdminRouter = require('server/admin/router')
-const SlackRouter = require('server/slack/router')
-const Logger = require('util/logger')
+const AuthorizationRouter = require('src/server/authorization/router')
+const AdminRouter = require('src/server/admin/router')
+const SlackRouter = require('src/server/slack/router')
+const Logger = require('src/util/logger')
 
 const app = express()
 
@@ -17,6 +18,16 @@ app.use(bodyParser.urlencoded({
   extended: true
 }))
 app.use(morgan('dev'))
+
+app.engine('html', cons.swig);
+app.set('view engine', 'html');
+app.set('views', __dirname + '/public')
+
+app.get('/', (req, res) => {
+  res.render('index.html', {
+    baseUri: config.get('app.baseUri')
+  })
+})
 
 app.use('/api/auth', AuthorizationRouter)
 app.use('/api/admin', AdminRouter)

--- a/src/server/public/index.html
+++ b/src/server/public/index.html
@@ -1,0 +1,7 @@
+<a href="https://slack.com/oauth/authorize?scope=commands&client_id=4495105526.130420612470&state=f57e62a1-2e21-473c-9e8b-a17215a32104">
+    <img alt="Add to Slack" height="40" width="139"
+         src="https://platform.slack-edge.com/img/add_to_slack.png"
+         srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" />
+</a>
+
+<a href="{{ baseUri }}/api/auth/spotify">Authorize Spotify</a>

--- a/src/server/slack/controller.js
+++ b/src/server/slack/controller.js
@@ -2,16 +2,33 @@
 
 const _ = require('lodash')
 const config = require('config')
+const xform = require('x-www-form-urlencode')
 
 function authorizeSlack(req, res, next) {
 
-  const token = _.get(req, 'body.token')
+  const token = _getTokenFromRequest(req)
 
-  if (!token || token !== config.get('slack.token')) {
+  const doesntMatchEitherToken = (token !== config.get('slack.token') && 
+  token !== config.get('slack.verificationToken'))
+
+  if (!token || doesntMatchEitherToken) {
     return next(new Error('Invalid Slack Token!'))
   }
 
   next()
+}
+
+function _getTokenFromRequest(req) {
+
+  let token = _.get(req, 'body.token')
+
+  if (!token && req.body.payload) {
+    let payload = JSON.parse(xform.decode(req.body.payload))
+    token = _.get(payload, 'token')
+    req.body = payload
+  }
+
+  return token
 }
 
 module.exports = {

--- a/src/server/slack/serializer.js
+++ b/src/server/slack/serializer.js
@@ -2,6 +2,8 @@
 
 const _ = require('lodash')
 
+const Constants = require('src/constants')
+
 function serializeSearchResults(query, results) {
 
   const attachments = _.map(
@@ -13,29 +15,32 @@ function serializeSearchResults(query, results) {
 
       return {
         color: _getRandomColor(),
-        author_name: artists,
         thumb_url: i.album.images[0].url,
 
-        title: i.name,
+        title: `${i.name} - ${artists}`,
         title_link: i.external_urls.spotify,
 
-        text: `ID --> ${i.id}`
+        callback_id: Constants.SLACK.INTERACTIVE.SONG_SEARCH.CALLBACK_ID,
+        actions: [
+          {
+            name: Constants.SLACK.INTERACTIVE.SONG_SEARCH.ACTION.ADD_SONG.NAME,
+            text: Constants.SLACK.INTERACTIVE.SONG_SEARCH.ACTION.ADD_SONG.TEXT,
+            type: 'button',
+            value: i.id
+          }
+        ]
       }
     }
   )
     .slice(0, 5)
 
-  let text = `Here's what we found for: _${query}_`
+  let text = `Here's what we found for: *${query}*`
 
   if (!attachments.length) {
-    text = `Sorry, mate. We couldn't find any results for that :\\`
+    text = `Sorry. We couldn't find any results for that 😞` // :disappointed: emoji
   }
 
-  return {
-    response_type: 'in_channel',
-    text,
-    attachments
-  }
+  return { response_type: 'in_channel', text, attachments }
 }
 
 function _getRandomColor() {

--- a/src/spotify/app.js
+++ b/src/spotify/app.js
@@ -1,10 +1,44 @@
 'use strict'
 
+const co = require('bluebird').coroutine
 const config = require('config')
 const debug = require('debug')('spotify-app')
 
-const Logger = require('util/logger')
-const spotifyClient = require('spotify/client')
+const Constants = require('src/constants')
+const Redis = require('src/db/redis')
+const Logger = require('src/util/logger')
+const spotifyClient = require('src/spotify/client')
+
+function init() {
+  return co(function* () {
+    
+    const refreshTokenFromStorage = yield Redis.client.getAsync(Constants.STORAGE_KEY.SPOTIFY.REFRESH_TOKEN)
+
+    if (refreshTokenFromStorage) {
+
+      debug(`Retrieved refresh token from storage.`)
+      spotifyClient.setRefreshToken(refreshTokenFromStorage)
+    }
+
+    yield refreshTokens()
+  })()
+}
+
+function refreshTokens() {
+  return co(function* () {
+
+    debug(`Refreshing tokens.`)
+    const data = yield spotifyClient.refreshAccessToken()
+    debug(`Refreshed tokens: ${JSON.stringify(data)}`)
+    spotifyClient.setAccessToken(data.body['access_token'])
+
+    if (data['refresh_token']) {
+      debug(`New refresh token received.`)
+      spotifyClient.setRefreshToken(data.body['refresh_token'])
+      yield Redis.client.setAsync(Constants.STORAGE_KEY.SPOTIFY.REFRESH_TOKEN, data.body['refresh_token'])
+    }
+  })()
+}
 
 function search(queryString) {
   return spotifyClient.searchTracks(queryString)
@@ -14,23 +48,28 @@ function search(queryString) {
 
       const items = r.body.tracks.items
       const response = {
-        status: 'found',
+        status: 'success',
         items
       }
 
       if (!items.length) {
-        response.status = 'not_found'
+        response.status = 'failure'
       }
 
       return response
+    })
+    .catch(err => {
+      Logger.error({ error: err, stack: err.stack })
+      return { status: 'failure' }
     })
 }
 
 function addTrackToTargetPlaylist(trackId) {
 
-  debug(`Making request:`, config.get('spotify.playlistUser'),
-    config.get('spotify.targetPlaylist'),
-    trackId)
+  debug(`Making request.`, `playlistUser: ${config.get('spotify.playlistUser')}`, 
+    `playlistId: ${config.get('spotify.targetPlaylist')}`, 
+    `trackId: ${trackId}`
+  )
 
   return spotifyClient.addTracksToPlaylist(
     config.get('spotify.playlistUser'),
@@ -39,20 +78,26 @@ function addTrackToTargetPlaylist(trackId) {
   )
     .then(r => {
       debug(JSON.stringify(r, null, 2))
-      return {
-        result: 'success'
-      }
+      return { status: Constants.RESULT.STATUS.SUCCESS }
     })
     .catch(err => {
       Logger.error({err, stack: err.stack})
-      return {
-        result: 'failure'
-      }
+      return { result: Constants.RESULT.STATUS.FAILURE }
     })
 }
 
+function getTrackFromId(trackId) {
+  return co(function* () {
+    const response = yield spotifyClient.getTracks([trackId])
+    return response.body.tracks[0]
+  })()
+}
+
 module.exports = {
+  init,
+  refreshTokens,
   client: spotifyClient,
   search,
-  addTrackToTargetPlaylist
+  addTrackToTargetPlaylist,
+  getTrackFromId
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,8 @@
+'use strict'
+
+import test from 'ava'
+const Server = require('src/server')
+
+test(t => {
+  Server.init()
+})


### PR DESCRIPTION
- Add an index page to serve the `Add Slack` and `Authorize Spotify` buttons.
- Add a lot of debugging statements.
- Update absolute paths to have `src` in the beginning to distinguish them from conflicting node packages.
- Verify slack oAuth state to ensure request is coming from our own page.
- Store spotify access and refresh tokens in Redis.
- Add token check in slack authorization for both the token received in slash command and the token received in interactive commands.
- Add interactive buttons on song search to add song to pre-defined playlist.
- Add a constants file with various type of constants and messaging templates.
- Add a spotify init function to be run at app startup to verify presence of refresh token and get fresh tokens.
- Update `package.json` entries to all have fixed versions to avoid auto-updating packages.
- Add simple ava testing to verify bootup.