### PR TITLE
Use nyc to get test coverage report, integrate coveralls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea
 node_modules
+.nyc_output
+/coverage

--- a/bin/docker-test.sh
+++ b/bin/docker-test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+docker-compose -f docker-compose.test.yml -p ci up --build --abort-on-container-exit
+
+exit $(docker wait ci_taptapboom_1)

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
-docker-compose -f docker-compose.test.yml -p ci up --build --abort-on-container-exit
+npm run test
 
-exit $(docker wait ci_taptapboom_1)
+# run coverage-coveralls only if COVERALLS_REPO_TOKEN env variable is set
+if ! [ -z ${COVERALLS_REPO_TOKEN+x} ]; then npm run coverage-coveralls; fi

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
 docker-compose -f docker-compose.test.yml -p ci up --build --abort-on-container-exit
+
+exit $(docker wait ci_taptapboom_1)

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,6 +5,6 @@ taptapboom:
   links:
     - redis
   working_dir: /usr/src/app
-  command: bash -c "npm test"
+  command: bash -c "npm test && npm run coverage-coveralls"
 redis:
   image: redis:3.2

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -7,6 +7,6 @@ taptapboom:
   links:
     - redis
   working_dir: /usr/src/app
-  command: bash -c "npm test && npm run coverage-coveralls"
+  command: bash -c "./bin/test.sh"
 redis:
   image: redis:3.2

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,5 +1,7 @@
 taptapboom:
   build: .
+  environment:
+    - COVERALLS_REPO_TOKEN
   env_file:
     - bin/test.env
   links:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "ava",
+    "test": "nyc ava",
+    "coverage-html": "nyc report --reporter=html",
+    "coverage-coveralls": "nyc report --reporter=text-lcov | coveralls",
     "docker-test": "bin/test.sh"
   },
   "author": "Shaun",
@@ -30,6 +32,8 @@
     "x-www-form-urlencode": "0.1.1"
   },
   "devDependencies": {
-    "ava": "^0.17.0"
+    "ava": "0.17.0",
+    "coveralls": "2.11.15",
+    "nyc": "10.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "nyc ava",
     "coverage-html": "nyc report --reporter=html",
     "coverage-coveralls": "nyc report --reporter=text-lcov | coveralls",
-    "docker-test": "bin/test.sh"
+    "docker-test": "bin/docker-test.sh"
   },
   "author": "Shaun",
   "license": "ISC",


### PR DESCRIPTION
- Extend docker-compose.test commands to generate coverage report after running tests
- Add nyc, coveralls npm dev dependencies
- Add coverage-html, coverage-coveralls npm scripts
- Add .nyc_output, /coverage to gitignore