### PR TITLE
Use -e flag to fail docker test command early on npm test error

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -7,6 +7,6 @@ taptapboom:
   links:
     - redis
   working_dir: /usr/src/app
-  command: bash -c "./bin/test.sh"
+  command: bash -e ./bin/test.sh
 redis:
   image: redis:3.2


### PR DESCRIPTION
- Fix #17